### PR TITLE
Update birthday page: hero text, countdown, sticky bar, section reorder

### DIFF
--- a/arjun-birthday.html
+++ b/arjun-birthday.html
@@ -118,7 +118,7 @@
             font-family: 'Boogaloo', cursive;
             font-size: 1.4rem;
             color: var(--leaf);
-            letter-spacing: 3px;
+            letter-spacing: 4px;
             text-transform: uppercase;
             margin: 0.5rem 0;
         }
@@ -130,6 +130,15 @@
             text-shadow: 4px 4px 0 rgba(0,0,0,0.3);
             line-height: 1;
             animation: slamIn 0.8s 0.3s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+        }
+
+        .hero-age-sub {
+            font-family: 'Bubblegum Sans', cursive;
+            font-size: clamp(1.8rem, 5vw, 3rem);
+            color: var(--gold);
+            text-shadow: 2px 2px 0 rgba(0,0,0,0.3);
+            line-height: 1.1;
+            animation: slamIn 0.8s 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) both;
         }
 
         @keyframes slamIn {
@@ -184,6 +193,10 @@
             box-shadow: 4px 7px 0 rgba(0,0,0,0.3);
         }
 
+        .cd-box { background:rgba(255,255,255,0.1); border:2px solid rgba(255,255,255,0.2); border-radius:14px; padding:12px 16px; text-align:center; min-width:72px; backdrop-filter:blur(4px); }
+        .cd-num { display:block; font-family:'Bubblegum Sans',cursive; font-size:2.2rem; color:var(--gold); line-height:1; text-shadow:2px 2px 0 rgba(0,0,0,0.3); }
+        .cd-lbl { display:block; font-family:'Boogaloo',cursive; font-size:0.65rem; color:rgba(255,255,255,0.5); letter-spacing:2px; margin-top:2px; }
+
         .scroll-hint {
             margin-top: 1.2rem;
             font-family: 'Boogaloo', cursive;
@@ -193,32 +206,8 @@
             animation: bob 2s ease-in-out infinite;
         }
 
-        /* ===== STICKY RSVP BUTTON (MOBILE) ===== */
-        .sticky-rsvp {
-            display: none;
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            z-index: 999;
-            background: linear-gradient(135deg, var(--jungle), var(--forest));
-            padding: 0.7rem 1rem;
-            text-align: center;
-            box-shadow: 0 -4px 20px rgba(0,0,0,0.2);
-        }
-        .sticky-rsvp a {
-            display: block;
-            color: var(--gold);
-            font-family: 'Bubblegum Sans', cursive;
-            font-size: 1.15rem;
-            text-decoration: none;
-            letter-spacing: 1px;
-        }
-        .sticky-rsvp.hidden { transform: translateY(100%); }
-        @media (max-width: 600px) {
-            .sticky-rsvp { display: block; }
-            body { padding-bottom: 3.2rem; }
-        }
+        /* ===== STICKY RSVP BAR ===== */
+        body { padding-bottom: 60px; }
 
         @keyframes bob {
             0%, 100% { transform: translateY(0); }
@@ -608,8 +597,9 @@
     <div class="hero-content">
         <div class="ribbon">✦ 🎉 YOU ARE INVITED! 🎉 ✦</div>
         <div class="hero-name">Arjun</div>
-        <div class="hero-turning label-font">is turning</div>
-        <div class="hero-age">6!</div>
+        <div class="hero-turning label-font">Hatched</div>
+        <div class="hero-age">6</div>
+        <div class="hero-age-sub">Years Ago!</div>
 
         <div class="dino-container">
             <svg viewBox="0 0 340 280" xmlns="http://www.w3.org/2000/svg">
@@ -691,6 +681,12 @@
 
         <div class="hero-date label-font">Saturday · March 28, 2026 · 12–2 PM</div>
         <div class="hero-venue">Urban Air Adventure Park · Aurora, CO</div>
+        <div id="countdown" style="display:flex; gap:12px; justify-content:center; margin:16px 0; flex-wrap:wrap;">
+            <div class="cd-box"><span class="cd-num" id="cd-days">00</span><span class="cd-lbl">DAYS</span></div>
+            <div class="cd-box"><span class="cd-num" id="cd-hours">00</span><span class="cd-lbl">HRS</span></div>
+            <div class="cd-box"><span class="cd-num" id="cd-mins">00</span><span class="cd-lbl">MINS</span></div>
+            <div class="cd-box"><span class="cd-num" id="cd-secs">00</span><span class="cd-lbl">SECS</span></div>
+        </div>
         <a href="#rsvp" class="hero-rsvp-btn">🦖 RSVP Now!</a>
         <div class="scroll-hint label-font">▼ SCROLL FOR DETAILS ▼</div>
     </div>
@@ -742,25 +738,15 @@
             <div class="card-title">Lunch</div>
             <div class="card-sub">Pizza, drinks & birthday cake<br>on us — come hungry!</div>
         </div>
-        <div class="detail-card reveal">
+        <div class="detail-card reveal" style="grid-column: 1 / -1;">
             <div class="card-icon">🤸</div>
-            <div class="card-title">All-Day Play</div>
-            <div class="card-sub">Kids get full-day access<br>to all attractions!</div>
+            <div class="card-title">All-Day Play Included! 🤸</div>
+            <div class="card-sub">Every kid gets full-day access to ALL Urban Air attractions — trampolines, climbing walls, obstacle courses and more. Play starts when the party begins!</div>
         </div>
     </div>
 
     <div class="reveal">
         <a href="https://maps.google.com/?q=15400+E+Briarwood+Circle+Aurora+CO+80016" target="_blank" class="map-btn">📍 Open in Google Maps</a>
-    </div>
-</section>
-
-<!-- ===== WAIVER ===== -->
-<section class="waiver">
-    <div class="waiver-box reveal">
-        <div class="waiver-icon">📋</div>
-        <h2 class="heading-font">Waiver Required!</h2>
-        <p>All kids must have a signed waiver <strong>before arriving</strong> at Urban Air. Please complete it ahead of time so the kiddos can jump right into the fun — no delays at check-in!</p>
-        <a href="https://booking.urbanairparks.com/waiver?confirmation=1316262-las5zhyp" target="_blank" class="waiver-btn">✍️ Sign Waiver Now →</a>
     </div>
 </section>
 
@@ -824,21 +810,32 @@
         <div class="success-state" id="successState">
             <div class="big-emoji">🥳</div>
             <h3>ROAR! You're on the list!</h3>
-            <p>Thanks for RSVPing! We can't wait to see you at the Dino Party. Don't forget to sign the waiver!</p>
+            <p>Thanks for RSVPing! One more thing — please sign the Urban Air waiver below before the big day. It takes 2 minutes and saves time at check-in!</p>
         </div>
     </div>
 </section>
 
-<!-- ===== STICKY RSVP (MOBILE) ===== -->
-<div class="sticky-rsvp" id="stickyRsvp">
-    <a href="#rsvp">🦖 RSVP for Arjun's Party!</a>
-</div>
+<!-- ===== WAIVER ===== -->
+<section class="waiver">
+    <div class="waiver-box reveal">
+        <div class="waiver-icon">📋</div>
+        <h2 class="heading-font">Waiver Required!</h2>
+        <p>All kids must have a signed waiver <strong>before arriving</strong> at Urban Air. Please complete it ahead of time so the kiddos can jump right into the fun — no delays at check-in!</p>
+        <a href="https://booking.urbanairparks.com/waiver?confirmation=1316262-las5zhyp" target="_blank" class="waiver-btn">✍️ Sign Waiver Now →</a>
+    </div>
+</section>
 
 <!-- ===== FOOTER ===== -->
 <footer class="footer">
     <div class="dino-row">🦕 🦖 🦕</div>
     <p>MADE WITH LOVE FOR ARJUN'S 6TH BIRTHDAY · MARCH 28, 2026</p>
 </footer>
+
+<!-- ===== STICKY RSVP BAR ===== -->
+<div id="stickyRsvp" style="position:fixed; bottom:0; left:0; right:0; z-index:999; background:linear-gradient(135deg,#1a3a2a,#2d6a4f); padding:14px 20px; display:flex; align-items:center; justify-content:center; gap:16px; box-shadow:0 -4px 24px rgba(0,0,0,0.3); transform:translateY(0); transition:transform 0.3s ease;">
+    <span style="font-family:'Boogaloo',cursive; font-size:1rem; color:rgba(255,255,255,0.8); letter-spacing:1px;">🦕 Arjun's Party — March 28!</span>
+    <a href="#rsvp" style="background:var(--gold); color:var(--jungle); font-family:'Bubblegum Sans',cursive; font-size:1.1rem; padding:9px 24px; border-radius:50px; text-decoration:none; font-weight:700; box-shadow:3px 3px 0 rgba(0,0,0,0.2); white-space:nowrap;">RSVP Now 🦕</a>
+</div>
 
 <script>
     // ===== CONFIG =====
@@ -893,6 +890,29 @@
         draw();
     })();
 
+    // ===== COUNTDOWN TIMER =====
+    (function() {
+        const party = new Date('2026-03-28T12:00:00');
+        function tick() {
+            const now = new Date();
+            const diff = party - now;
+            if (diff <= 0) {
+                document.getElementById('countdown').innerHTML = '<div style="font-family:Bubblegum Sans,cursive;font-size:1.5rem;color:var(--gold)">🦕 Party Time! ROAR! 🦕</div>';
+                return;
+            }
+            const d = Math.floor(diff / 86400000);
+            const h = Math.floor((diff % 86400000) / 3600000);
+            const m = Math.floor((diff % 3600000) / 60000);
+            const s = Math.floor((diff % 60000) / 1000);
+            document.getElementById('cd-days').textContent = String(d).padStart(2,'0');
+            document.getElementById('cd-hours').textContent = String(h).padStart(2,'0');
+            document.getElementById('cd-mins').textContent = String(m).padStart(2,'0');
+            document.getElementById('cd-secs').textContent = String(s).padStart(2,'0');
+        }
+        tick();
+        setInterval(tick, 1000);
+    })();
+
     // ===== SCROLL REVEAL =====
     (function() {
         const reveals = document.querySelectorAll('.reveal');
@@ -909,7 +929,7 @@
                     observer.unobserve(el);
                 }
             });
-        }, { threshold: 0.15 });
+        }, { threshold: 0.05 });
         reveals.forEach(el => observer.observe(el));
     })();
 


### PR DESCRIPTION
- Hero: "is turning 6!" → "Hatched 6 Years Ago!" with styled subtitle
- All-Day Play card spans full width with detailed description
- Added live countdown timer to hero section
- New sticky RSVP bar visible on all screen sizes
- Reordered sections: Details → RSVP → Waiver (logical flow)
- Updated RSVP success message to guide users to waiver
- Lowered scroll reveal threshold from 0.15 to 0.05

https://claude.ai/code/session_016AUoaFwEuumirm6i36ktR3