### PR TITLE
Fix: remove HTML required attributes from RSVP form

### DIFF
--- a/arjun-birthday.html
+++ b/arjun-birthday.html
@@ -777,13 +777,13 @@
     <div class="rsvp-card reveal">
         <form id="rsvpForm">
             <div class="form-group">
-                <label>Parent / Guardian Name *</label>
-                <input type="text" id="parent_name" required placeholder="Your name">
+                <label>Parent / Guardian Name</label>
+                <input type="text" id="parent_name" placeholder="Your name">
             </div>
             <div class="form-row">
                 <div class="form-group">
-                    <label>Phone *</label>
-                    <input type="tel" id="phone" required placeholder="(555) 123-4567">
+                    <label>Phone</label>
+                    <input type="tel" id="phone" placeholder="(555) 123-4567">
                 </div>
                 <div class="form-group">
                     <label>Email</label>
@@ -791,8 +791,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label>Child(ren)'s Name(s) *</label>
-                <input type="text" id="child_name" required placeholder="e.g. Ava, Max">
+                <label>Child(ren)'s Name(s)</label>
+                <input type="text" id="child_name" placeholder="e.g. Ava, Max">
             </div>
             <div class="form-row">
                 <div class="form-group">


### PR DESCRIPTION
Removes `required` attributes and `*` asterisks from parent name, phone, and child name fields. The JS validation array was already cleared but browser-native validation was still blocking empty submissions.

https://claude.ai/code/session_016AUoaFwEuumirm6i36ktR3