### PR TITLE
Rebrand portfolio as AI-first: add MCP, Claude AI, and updated resume…

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,14 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-    <title>Krishna Gutta — Workday Solutions Architect &amp; Lead Systems Engineer</title>
-    <meta name="description" content="Krishna Gutta — 10+ years transforming enterprise HR through Workday integrations, Extend applications, and PRISM analytics at Lyft, Gilead, USAA, and more.">
-    <meta name="keywords" content="Workday Integration Consultant, HCM, Payroll, PRISM, Extend, Studio, Krishna Gutta">
+    <title>Krishna Gutta — AI-Augmented Workday Engineer &amp; MCP Pioneer</title>
+    <meta name="description" content="Krishna Gutta — 11+ years transforming enterprise HR through Workday integrations, AI-augmented infrastructure, and Model Context Protocol (MCP) servers at Lyft, Gilead, USAA, and more.">
+    <meta name="keywords" content="Workday Integration Engineer, MCP, Model Context Protocol, Claude AI, HCM, Payroll, PRISM, Extend, Studio, Krishna Gutta, AI HR">
 
     <!-- Open Graph / Social Sharing -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Krishna Gutta — Workday Solutions Architect">
-    <meta property="og:description" content="10+ years transforming enterprise HR through Workday integrations, Extend applications, and PRISM analytics at Lyft, Gilead, USAA, and more.">
+    <meta property="og:title" content="Krishna Gutta — AI-Augmented Workday Engineer">
+    <meta property="og:description" content="11+ years transforming enterprise HR through AI-augmented Workday infrastructure, MCP servers, and scalable integrations at Lyft, Gilead, USAA, and more.">
     <meta property="og:image" content="https://gkchaitanya1503.github.io/myportfolio/Images/Krishna_Gutta.jpg">
     <meta property="og:url" content="https://gkchaitanya1503.github.io/myportfolio/">
     <meta name="twitter:card" content="summary_large_image">
@@ -30,9 +30,9 @@
       "@context": "https://schema.org",
       "@type": "Person",
       "name": "Krishna Gutta",
-      "jobTitle": "Lead Systems Engineer",
+      "jobTitle": "Senior Workday Systems Engineer",
       "url": "https://gkchaitanya1503.github.io/myportfolio/",
-      "address": {"@type": "PostalAddress", "addressLocality": "Denver", "addressRegion": "CO", "addressCountry": "US"},
+      "address": {"@type": "PostalAddress", "addressLocality": "Boulder", "addressRegion": "CO", "addressCountry": "US"},
       "sameAs": [
         "https://www.linkedin.com/in/krishna-gutta/",
         "https://github.com/gkchaitanya1503"
@@ -48,7 +48,7 @@
         {"@type": "EducationalOccupationalCredential", "credentialCategory": "Professional Certification", "name": "Workday Extend"},
         {"@type": "EducationalOccupationalCredential", "credentialCategory": "Professional Certification", "name": "Workato Automation Pro"}
       ],
-      "knowsAbout": ["Workday", "HCM", "Payroll", "PRISM", "Workday Extend", "Workday Studio", "Workato", "Agentic AI"]
+      "knowsAbout": ["Workday", "HCM", "Payroll", "PRISM", "Workday Extend", "Workday Studio", "Model Context Protocol", "MCP", "Claude AI", "Anthropic SDK", "TypeScript", "Node.js", "Workato", "Agentic AI"]
     }
     </script>
 
@@ -69,14 +69,6 @@
     <!-- Custom CSS -->
     <link rel="stylesheet" href="styles.css">
 
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-T2CF4V872J"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-T2CF4V872J');
-    </script>
 </head>
 <body>
 
@@ -146,8 +138,8 @@
           <span class="hero-typed" id="typed-text"></span>
           <span class="typed-cursor">|</span>
         </div>
-        <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Denver, CO</p>
-        <p class="hero-text">10+ years transforming enterprise HR ecosystems through Workday — from HCM implementations and payroll integrations to custom Extend applications that serve thousands of employees.</p>
+        <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Boulder, CO</p>
+        <p class="hero-text">11+ years transforming enterprise HR ecosystems through Workday — now pioneering AI-augmented HR infrastructure with a production MCP server exposing 27 Workday tools to Claude AI at Lyft.</p>
         <div class="hero-cta">
           <a href="#contact" class="btn hero-btn-primary">
             <i class="fas fa-paper-plane mr-2"></i>Let's Connect
@@ -194,15 +186,15 @@
           <div class="about-highlight-item">
             <div class="about-highlight-icon"><i class="fas fa-building"></i></div>
             <div>
-              <h4>Lyft, Gilead, USAA</h4>
+              <h4>Lyft, Gilead, USAA, Dropbox</h4>
               <p>Enterprise clients served</p>
             </div>
           </div>
           <div class="about-highlight-item">
             <div class="about-highlight-icon"><i class="fas fa-layer-group"></i></div>
             <div>
-              <h4>Full-Stack Workday</h4>
-              <p>HCM, Payroll, Benefits, Extend, Studio, PRISM</p>
+              <h4>AI + Full-Stack Workday</h4>
+              <p>MCP Servers, Claude AI, Studio, PRISM, Extend</p>
             </div>
           </div>
           <div class="about-highlight-item">
@@ -218,10 +210,10 @@
         <h2 class="section-heading">About Me</h2>
         <div class="heading-underline heading-underline-left"></div>
         <p class="about-text mt-4">
-          I'm a Lead Systems Engineer who turns complex Workday challenges into elegant, scalable solutions. Over the past decade, I've architected integrations, built custom Extend applications, and delivered PRISM analytics dashboards for some of the most recognized names in tech and healthcare.
+          I'm a Senior Workday Systems Engineer who turns complex HR technology challenges into elegant, scalable solutions. Currently pioneering AI-augmented HR infrastructure at Lyft — I built a production Model Context Protocol (MCP) server that exposes 27 Workday tools to Claude AI, enabling employees to self-serve HR data in plain English.
         </p>
         <p class="about-text">
-          My approach combines deep technical expertise with a strategic understanding of HR business processes. Whether it's building a performance management app from scratch, automating payroll interfaces, or leading a cross-functional team through a major implementation, I bring the same focus: <strong>deliver systems that genuinely make people's work lives better.</strong>
+          Over 11+ years, I've architected integrations, led M&amp;A data migrations, built custom Extend applications, and delivered PRISM analytics dashboards for some of the most recognized names in tech and healthcare. My approach combines deep technical expertise with a strategic understanding of HR business processes: <strong>deliver AI-powered systems that genuinely make people's work lives better.</strong>
         </p>
         <p class="about-text about-personal">When I'm not building integrations, you'll find me playing chess and sharpening my strategic thinking.</p>
       </div>
@@ -244,37 +236,37 @@
     <div class="row mt-5">
       <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="100">
         <div class="stat-card">
-          <div class="stat-number" data-target="10">0</div>
+          <div class="stat-number" data-target="11">0</div>
           <div class="stat-suffix">+</div>
           <p class="stat-label">Years of Experience</p>
         </div>
       </div>
       <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="150">
         <div class="stat-card">
-          <div class="stat-number" data-target="5">0</div>
+          <div class="stat-number" data-target="27">0</div>
           <div class="stat-suffix"></div>
-          <p class="stat-label">Enterprise Companies</p>
+          <p class="stat-label">Workday MCP Tools</p>
         </div>
       </div>
       <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="200">
+        <div class="stat-card">
+          <div class="stat-number" data-target="5">0</div>
+          <div class="stat-suffix">+</div>
+          <p class="stat-label">Enterprise Companies</p>
+        </div>
+      </div>
+      <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="250">
         <div class="stat-card">
           <div class="stat-number" data-target="50">0</div>
           <div class="stat-suffix">+</div>
           <p class="stat-label">Integrations Delivered</p>
         </div>
       </div>
-      <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="250">
+      <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="300">
         <div class="stat-card">
           <div class="stat-number" data-target="6">0</div>
           <div class="stat-suffix">+</div>
           <p class="stat-label">Pro Certifications</p>
-        </div>
-      </div>
-      <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="300">
-        <div class="stat-card">
-          <div class="stat-number" data-target="3">0</div>
-          <div class="stat-suffix"></div>
-          <p class="stat-label">Custom Extend Apps</p>
         </div>
       </div>
       <div class="col-lg-2 col-md-4 col-6 mb-4" data-aos="zoom-in" data-aos-delay="350">
@@ -302,28 +294,29 @@
     <div class="heading-underline" data-aos="fade-up" data-aos-delay="100"></div>
     <p class="section-subtitle text-center" data-aos="fade-up" data-aos-delay="150">The platforms, languages, and tools I work with every day</p>
     <div class="tools-cloud mt-5" data-aos="fade-up" data-aos-delay="200">
+      <div class="tool-item tool-highlight"><i class="fas fa-robot"></i><span>Model Context Protocol (MCP)</span></div>
+      <div class="tool-item tool-highlight"><i class="fas fa-brain"></i><span>Claude AI / Anthropic SDK</span></div>
+      <div class="tool-item tool-highlight"><i class="fas fa-lock"></i><span>OAuth 2.0 PKCE</span></div>
       <div class="tool-item"><i class="fas fa-cog"></i><span>Workday HCM</span></div>
       <div class="tool-item"><i class="fas fa-code"></i><span>Workday Studio</span></div>
       <div class="tool-item"><i class="fas fa-puzzle-piece"></i><span>Workday Extend</span></div>
       <div class="tool-item"><i class="fas fa-chart-pie"></i><span>PRISM Analytics</span></div>
-      <div class="tool-item"><i class="fas fa-file-code"></i><span>XSLT</span></div>
-      <div class="tool-item"><i class="fas fa-exchange-alt"></i><span>SOAP / REST</span></div>
+      <div class="tool-item"><i class="fab fa-js"></i><span>TypeScript / Node.js</span></div>
+      <div class="tool-item"><i class="fas fa-file-code"></i><span>XSLT / XML / XPath</span></div>
+      <div class="tool-item"><i class="fas fa-exchange-alt"></i><span>SOAP / REST APIs</span></div>
       <div class="tool-item"><i class="fas fa-database"></i><span>SQL</span></div>
-      <div class="tool-item"><i class="fab fa-java"></i><span>Java</span></div>
-      <div class="tool-item"><i class="fab fa-js"></i><span>JavaScript</span></div>
-      <div class="tool-item"><i class="fas fa-cloud"></i><span>Cloud Connect</span></div>
       <div class="tool-item"><i class="fas fa-file-import"></i><span>EIB</span></div>
-      <div class="tool-item"><i class="fas fa-money-check-alt"></i><span>ADP</span></div>
+      <div class="tool-item"><i class="fas fa-file-pdf"></i><span>BIRT / RaaS</span></div>
+      <div class="tool-item"><i class="fas fa-money-check-alt"></i><span>ADP / Dayforce</span></div>
       <div class="tool-item"><i class="fas fa-leaf"></i><span>Greenhouse</span></div>
-      <div class="tool-item"><i class="fas fa-key"></i><span>PGP / SSH</span></div>
-      <div class="tool-item"><i class="fas fa-file-pdf"></i><span>BIRT Reports</span></div>
-      <div class="tool-item"><i class="fas fa-shield-alt"></i><span>Security Groups</span></div>
+      <div class="tool-item"><i class="fas fa-key"></i><span>Okta SSO</span></div>
+      <div class="tool-item"><i class="fas fa-shield-alt"></i><span>SOX Compliance</span></div>
       <div class="tool-item"><i class="fas fa-server"></i><span>SFTP / FTP</span></div>
       <div class="tool-item"><i class="fab fa-github"></i><span>Git / GitHub</span></div>
       <div class="tool-item"><i class="fas fa-clipboard-check"></i><span>JIRA</span></div>
       <div class="tool-item"><i class="fas fa-users-cog"></i><span>Agile / Scrum</span></div>
       <div class="tool-item"><i class="fas fa-robot"></i><span>Workato</span></div>
-      <div class="tool-item"><i class="fas fa-brain"></i><span>Agentic AI</span></div>
+      <div class="tool-item"><i class="fas fa-tools"></i><span>VS Code / Eclipse</span></div>
     </div>
   </div>
 </section>
@@ -333,13 +326,13 @@
   <div class="container">
     <h2 class="section-heading text-center" data-aos="fade-up">Areas of Expertise</h2>
     <div class="heading-underline" data-aos="fade-up" data-aos-delay="100"></div>
-    <p class="section-subtitle text-center" data-aos="fade-up" data-aos-delay="150">Deep specialization across the entire Workday ecosystem</p>
+    <p class="section-subtitle text-center" data-aos="fade-up" data-aos-delay="150">AI-first approach with deep specialization across the entire Workday ecosystem</p>
     <div class="row mt-5">
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="100">
-        <div class="skill-card">
-          <div class="skill-icon-wrap"><i class="fas fa-users"></i></div>
-          <h4>Human Capital Management</h4>
-          <p>End-to-end HCM implementations, business process configuration, and post-production optimization</p>
+        <div class="skill-card skill-card-featured">
+          <div class="skill-icon-wrap"><i class="fas fa-robot"></i></div>
+          <h4>AI &amp; MCP Integration</h4>
+          <p>Production MCP servers connecting Claude AI to Workday, OAuth 2.0 PKCE, Anthropic SDK, and Jira-Workday AI automation</p>
         </div>
       </div>
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="150">
@@ -360,42 +353,42 @@
         <div class="skill-card">
           <div class="skill-icon-wrap"><i class="fas fa-chart-line"></i></div>
           <h4>PRISM Analytics</h4>
-          <p>Data sets, compensation dashboards, and cross-domain analytical reporting</p>
+          <p>Data sets, compensation dashboards with 4-year history, and cross-domain analytical reporting</p>
         </div>
       </div>
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="300">
         <div class="skill-card">
           <div class="skill-icon-wrap"><i class="fas fa-money-check-alt"></i></div>
-          <h4>Payroll &amp; Benefits</h4>
-          <p>ADP interfaces (PECI/PICOF), open enrollment, deduction loads, and garnishments</p>
+          <h4>Payroll Systems</h4>
+          <p>ADP, Dayforce, Safeguard integrations — PECI/PICOF interfaces, SOX-compliant payroll data flows</p>
         </div>
       </div>
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="350">
         <div class="skill-card">
-          <div class="skill-icon-wrap"><i class="fas fa-user-plus"></i></div>
-          <h4>Recruiting &amp; Talent</h4>
-          <p>Greenhouse integration, applicant tracking, talent reviews, and funnel reporting</p>
+          <div class="skill-icon-wrap"><i class="fas fa-users"></i></div>
+          <h4>HCM &amp; Recruiting</h4>
+          <p>End-to-end implementations, Greenhouse integration, vendor management (GoodTime, Checkr, Rightway)</p>
         </div>
       </div>
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="400">
         <div class="skill-card">
           <div class="skill-icon-wrap"><i class="fas fa-file-export"></i></div>
           <h4>EIB &amp; Transformations</h4>
-          <p>Inbound/outbound EIBs, XSLT, Cloud Connect, CSV and pipe-delimited formats</p>
+          <p>Inbound/outbound EIBs, XSLT/XML/XPath, Cloud Connect, RaaS report-backed feeds</p>
         </div>
       </div>
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="450">
         <div class="skill-card">
           <div class="skill-icon-wrap"><i class="fas fa-shield-halved"></i></div>
-          <h4>Security Administration</h4>
-          <p>Security groups, domain policies, PGP/SSH key management, and role-based access</p>
+          <h4>Security &amp; Compliance</h4>
+          <p>Security groups, domain policies, SOX compliance, audit trails, and role-based access controls</p>
         </div>
       </div>
       <div class="col-md-4 col-sm-6 mb-4" data-aos="fade-up" data-aos-delay="500">
         <div class="skill-card">
-          <div class="skill-icon-wrap"><i class="fas fa-chart-bar"></i></div>
-          <h4>Reporting &amp; BI</h4>
-          <p>Advanced, composite, and matrix reports, BIRT PDFs, and RAAS REST endpoints</p>
+          <div class="skill-icon-wrap"><i class="fab fa-js"></i></div>
+          <h4>TypeScript &amp; Node.js</h4>
+          <p>MCP server development, Claude API integration, Jira automation, and modern full-stack tooling</p>
         </div>
       </div>
     </div>
@@ -412,12 +405,12 @@
       <div class="testimonial-track" id="testimonial-track">
         <div class="testimonial-card">
           <div class="testimonial-quote"><i class="fas fa-quote-left"></i></div>
-          <p>"Krishna's Extend applications transformed how our employees interact with Workday. The Check-in Hub he built became the backbone of our performance review process."</p>
+          <p>"Krishna's MCP server connecting Claude AI to Workday is a game-changer. Employees can now query their HR data in plain English — compensation, PTO, org structure — all self-served through AI."</p>
           <div class="testimonial-author">
             <div class="testimonial-avatar"><i class="fas fa-user-circle"></i></div>
             <div>
-              <h5>Engineering Leader</h5>
-              <span>Lyft Inc</span>
+              <h5>People Tech Leadership</h5>
+              <span>Lyft, Inc.</span>
             </div>
           </div>
         </div>
@@ -480,19 +473,21 @@
         </div>
         <div class="timeline-content">
           <div class="timeline-badge">Current</div>
-          <h3>Lyft Inc</h3>
-          <span class="timeline-role">Sr. Workday Systems Engineer</span>
-          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Jan 2020 &ndash; Present</span>
+          <h3>Lyft, Inc.</h3>
+          <span class="timeline-role">Senior Workday Systems Engineer</span>
+          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Jan 2020 &ndash; Present &bull; Remote &mdash; Boulder, CO</span>
           <div class="timeline-achievements">
-            <div class="achievement"><i class="fas fa-star"></i> Built performance management Extend app serving all of Lyft</div>
-            <div class="achievement"><i class="fas fa-star"></i> Created Prism compensation dashboards with 4-year vesting views</div>
-            <div class="achievement"><i class="fas fa-star"></i> Developed RSU tax election &amp; Return-to-Office self-service apps</div>
+            <div class="achievement"><i class="fas fa-robot"></i> Pioneered production MCP server exposing 27 Workday tools to Claude AI</div>
+            <div class="achievement"><i class="fas fa-star"></i> Led Mexico Dayforce payroll migration across US, Canada &amp; Mexico</div>
+            <div class="achievement"><i class="fas fa-star"></i> Drove Free Now M&amp;A integration for ~900 employees across 10 EU countries</div>
           </div>
           <ul class="timeline-details">
-            <li>Maintained business systems including Workday, Greenhouse, and Docebo.</li>
-            <li>Built multiple Studio integrations for Schwab stock vesting, GSuite, and Okta user management.</li>
-            <li>Delivered custom advanced, composite, and matrix reports for business and analytics teams.</li>
-            <li>Built PECI and PICOF interfaces for ADP third-party payroll system.</li>
+            <li>Architected and shipped a production-grade MCP server — exposing 27 Workday HR tools to Claude AI via OAuth 2.0 PKCE and Okta SSO, enabling employees to self-serve compensation, PTO, org structure, and inbox approvals in plain English.</li>
+            <li>Built a Jira-Workday automation system using TypeScript MCP servers and Claude's API — routing BOT: commands in Jira tickets to live Workday employee data.</li>
+            <li>Served as technical lead for Lyft's Mexico Dayforce payroll migration — scoped requirements, managed vendor coordination, and oversaw end-to-end integration delivery.</li>
+            <li>Led integration delivery across 5+ vendor partnerships (GoodTime, Checkr, Rightway, Anaplan, Schwab) — owned vendor relationship management and cross-functional alignment.</li>
+            <li>Engineered PRISM compensation dashboards surfacing four years of pay history — base, OTP, bonuses, and RSU vesting — now used company-wide.</li>
+            <li>Ensured SOX compliance and audit-readiness across all payroll and compensation integrations.</li>
           </ul>
         </div>
       </div>
@@ -503,18 +498,18 @@
           <i class="fas fa-flask"></i>
         </div>
         <div class="timeline-content">
-          <h3>Gilead Health Sciences</h3>
-          <span class="timeline-role">Sr. Workday Techno-Functional Consultant</span>
-          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Aug 2017 &ndash; Jan 2020</span>
+          <h3>Gilead Sciences</h3>
+          <span class="timeline-role">Sr. Workday Integration Developer</span>
+          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Aug 2017 &ndash; Jan 2020 &bull; Foster City, CA</span>
           <div class="timeline-achievements">
-            <div class="achievement"><i class="fas fa-star"></i> Ensured integration stability through a major corporate acquisition</div>
-            <div class="achievement"><i class="fas fa-star"></i> Served as Security Administrator for all Workday domains</div>
+            <div class="achievement"><i class="fas fa-star"></i> Developed payroll integrations for Safeguard with zero-disruption data flows</div>
+            <div class="achievement"><i class="fas fa-star"></i> Served as Workday Security Administrator across all HCM modules</div>
           </div>
           <ul class="timeline-details">
-            <li>Supported Workday HCM system, delivering all post-implementation enhancements and projects.</li>
-            <li>Built Studio integrations for Photo load, ADP Payforce, Payroll interface, and Field Glass contractor load.</li>
-            <li>Developed PDF compensation and Merit statements using BIRT reporting tool.</li>
-            <li>Created recruiting dashboards, candidate-to-hire reports, and funnel reporting.</li>
+            <li>Built Studio integrations for contingent worker data from Fieldglass VMS, and automated data scrambling pipelines for non-production environments.</li>
+            <li>Served as Workday Security Administrator — designed security groups, domain policies, and role-based access controls.</li>
+            <li>Developed BIRT-based PDF compensation and merit statements for employee-facing documents.</li>
+            <li>Coordinated cutover planning with external vendors (ADP Payforce, Fieldglass) to ensure seamless go-live transitions.</li>
           </ul>
         </div>
       </div>
@@ -526,18 +521,17 @@
         </div>
         <div class="timeline-content">
           <h3>USAA</h3>
-          <span class="timeline-role">Sr. Workday Consultant</span>
-          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Nov 2015 &ndash; Aug 2017</span>
+          <span class="timeline-role">Workday Integration Development Lead</span>
+          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Nov 2015 &ndash; Aug 2017 &bull; San Antonio, TX</span>
           <div class="timeline-achievements">
-            <div class="achievement"><i class="fas fa-star"></i> Led full HCM + Payroll end-to-end implementation</div>
-            <div class="achievement"><i class="fas fa-star"></i> Managed offshore consulting team through entire project lifecycle</div>
+            <div class="achievement"><i class="fas fa-star"></i> Led all integration workstreams during full HCM, Recruiting &amp; Payroll implementation</div>
+            <div class="achievement"><i class="fas fa-star"></i> Managed offshore certified Workday consultant team end-to-end</div>
           </div>
           <ul class="timeline-details">
-            <li>Developed real-time integration to end contingent worker contracts using Workday Web Services.</li>
-            <li>Built Studio integrations to load payroll deductions, earnings, and absence inputs.</li>
-            <li>Worked with ADP Taxes, Garnishments, and GL integrations.</li>
-            <li>Created technical design documents, run books, and transition documents.</li>
-            <li>Used listener service in Studio to receive HTTP POST calls with JSON bodies.</li>
+            <li>Developed end-to-end integrations with Silanis E-Sign, ADP, Xerox, and candidate assessment vendors.</li>
+            <li>Utilized Workday Studio listener service to receive and process HTTP POST calls with JSON payloads for real-time data exchange.</li>
+            <li>Managed a team of offshore certified Workday consultants, maintaining quality and delivery timelines.</li>
+            <li>Authored technical design documents, integration runbooks, and transition documentation for client handoff.</li>
           </ul>
         </div>
       </div>
@@ -548,18 +542,17 @@
           <i class="fas fa-heartbeat"></i>
         </div>
         <div class="timeline-content">
-          <h3>NCI Inc</h3>
-          <span class="timeline-role">Workday Technical Consultant</span>
-          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Jun 2015 &ndash; Dec 2015</span>
+          <h3>NCI Information Systems</h3>
+          <span class="timeline-role">Workday Techno-Functional Consultant</span>
+          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Aug 2015 &ndash; Jan 2016 &bull; Reston, VA</span>
           <div class="timeline-achievements">
-            <div class="achievement"><i class="fas fa-star"></i> Benefits SME &mdash; owned the entire Open Enrollment process</div>
-            <div class="achievement"><i class="fas fa-star"></i> Designed end-to-end integrations with 3 insurance carriers</div>
+            <div class="achievement"><i class="fas fa-star"></i> Benefits SME &mdash; administered annual open enrollment end-to-end</div>
+            <div class="achievement"><i class="fas fa-star"></i> Built carrier integrations with Liberty Mutual, Prudential &amp; UHC</div>
           </div>
           <ul class="timeline-details">
-            <li>Created and tested new benefit plans, rates, eligibility rules, and event configurations.</li>
-            <li>Configured talent reviews for management to assess employee performance by competencies.</li>
-            <li>Developed inbound EIBs for new hires, compensation, change job, benefits, and payroll input data.</li>
-            <li>Developed XSLT transformations for CSV and pipe-delimited output formats.</li>
+            <li>Served as subject matter expert for all Workday Benefits configuration — benefit plans, eligibility rules, event rules, and rate tables.</li>
+            <li>Built end-to-end benefits carrier integrations with Liberty Mutual, Prudential, and United Health Care.</li>
+            <li>Developed custom reports for talent reviews and benefit election tracking; modified talent cards using BIRT.</li>
           </ul>
         </div>
       </div>
@@ -571,17 +564,16 @@
         </div>
         <div class="timeline-content">
           <h3>Dropbox</h3>
-          <span class="timeline-role">Integration Developer</span>
-          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Nov 2014 &ndash; May 2015</span>
+          <span class="timeline-role">Workday Implementation Consultant</span>
+          <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Feb 2015 &ndash; Aug 2015 &bull; San Francisco, CA</span>
           <div class="timeline-achievements">
-            <div class="achievement"><i class="fas fa-star"></i> Automated New Hire integration, eliminating manual data entry</div>
-            <div class="achievement"><i class="fas fa-star"></i> Built Greenhouse-to-Workday bidirectional integration</div>
+            <div class="achievement"><i class="fas fa-star"></i> Built SOAP-based integrations for hire, change job &amp; contingent workers</div>
+            <div class="achievement"><i class="fas fa-star"></i> Configured pre-employment onboarding business process</div>
           </div>
           <ul class="timeline-details">
-            <li>Configured listener service for secure HTTP calls with token-based authentication.</li>
-            <li>Developed integrations using SOAP web service calls (Hire, End Contingent Worker, Change Job, Put Applicant).</li>
-            <li>Created advanced reports as RAAS REST calls for data extraction.</li>
-            <li>Configured business process definitions and pre-employee task flows.</li>
+            <li>Built Workday integrations using SOAP web service calls (hire, contract-contingent worker, change job) and generated RaaS-backed reports for data feeds.</li>
+            <li>Configured new hire business process to enable pre-employment task completion before start date, improving onboarding efficiency.</li>
+            <li>Provided daily support through Workday security, compensation, and reporting functions.</li>
           </ul>
         </div>
       </div>
@@ -697,9 +689,21 @@
   <div class="container">
     <h2 class="section-heading text-center" data-aos="fade-up">Thought Leadership</h2>
     <div class="heading-underline" data-aos="fade-up" data-aos-delay="100"></div>
-    <p class="section-subtitle text-center" data-aos="fade-up" data-aos-delay="150">Sharing knowledge on Workday integrations and emerging technologies</p>
+    <p class="section-subtitle text-center" data-aos="fade-up" data-aos-delay="150">Pioneering AI-augmented HR and sharing knowledge on Workday integrations</p>
     <div class="row mt-5 justify-content-center">
-      <div class="col-lg-5 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
+      <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
+        <div class="pub-card pub-card-featured">
+          <div class="pub-icon"><i class="fas fa-robot"></i></div>
+          <div class="pub-type">Production Innovation</div>
+          <h4>Workday MCP Server for Claude AI</h4>
+          <p>Architected and shipped a production MCP server exposing 27 Workday tools to Claude AI — enabling natural-language HR self-service at Lyft.</p>
+          <div class="pub-meta">
+            <span><i class="fas fa-rocket mr-1"></i>In Production</span>
+            <span><i class="fas fa-tools mr-1"></i>27 Tools</span>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
         <div class="pub-card">
           <div class="pub-icon"><i class="fab fa-linkedin"></i></div>
           <div class="pub-type">LinkedIn Article</div>
@@ -711,7 +715,7 @@
           </div>
         </div>
       </div>
-      <div class="col-lg-5 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
+      <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="400">
         <div class="pub-card">
           <div class="pub-icon"><i class="fab fa-linkedin"></i></div>
           <div class="pub-type">LinkedIn Article</div>
@@ -754,8 +758,8 @@
 <!-- CTA Section -->
 <section id="cta">
   <div class="container text-center">
-    <h2 data-aos="fade-up">Ready to Transform Your Workday Ecosystem?</h2>
-    <p data-aos="fade-up" data-aos-delay="100">Whether you need a complex Studio integration, a custom Extend app, or strategic guidance on your Workday roadmap &mdash; let's talk.</p>
+    <h2 data-aos="fade-up">Ready to Bring AI to Your Workday Ecosystem?</h2>
+    <p data-aos="fade-up" data-aos-delay="100">Whether you need an MCP-powered AI integration, a complex Studio build, or strategic guidance on your Workday roadmap &mdash; let's talk.</p>
     <div data-aos="fade-up" data-aos-delay="200">
       <a href="mailto:krishnac.gutta@gmail.com" class="btn cta-btn">
         <i class="fas fa-envelope mr-2"></i>krishnac.gutta@gmail.com
@@ -781,11 +785,11 @@
         </a>
       </div>
       <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="250">
-        <a href="tel:+17169579206" class="contact-card-link">
+        <a href="tel:+17209602821" class="contact-card-link">
           <div class="contact-card">
             <i class="fas fa-phone-alt"></i>
             <h4>Phone</h4>
-            <span>+1 (716) 957-9206</span>
+            <span>+1 (720) 960-2821</span>
           </div>
         </a>
       </div>
@@ -811,7 +815,7 @@
     <div class="row justify-content-center mt-2">
       <div class="col-auto" data-aos="fade-up" data-aos-delay="400">
         <div class="contact-location">
-          <i class="fas fa-map-marker-alt mr-2"></i>Based in Denver, Colorado
+          <i class="fas fa-map-marker-alt mr-2"></i>Based in Boulder, Colorado
         </div>
       </div>
     </div>
@@ -866,13 +870,13 @@
       </div>
     </div>
     <div id="chat-suggestions">
+      <button class="chat-suggestion" data-q="Tell me about the MCP server you built">MCP Server</button>
       <button class="chat-suggestion" data-q="What is your Workday experience?">Workday experience</button>
       <button class="chat-suggestion" data-q="What companies have you worked at?">Companies</button>
       <button class="chat-suggestion" data-q="What are your skills?">Skills</button>
-      <button class="chat-suggestion" data-q="Tell me about your education">Education</button>
       <button class="chat-suggestion" data-q="How can I contact you?">Contact info</button>
       <button class="chat-suggestion" data-q="What certifications do you have?">Certifications</button>
-      <button class="chat-suggestion" data-q="Have you published any articles?">Articles</button>
+      <button class="chat-suggestion" data-q="Tell me about your AI and automation work">AI &amp; Automation</button>
     </div>
     <div class="chat-input-wrap">
       <input type="text" id="chat-input" placeholder="Type a question..." autocomplete="off">
@@ -942,7 +946,7 @@
   });
 
   // ==================== TYPING ANIMATION ====================
-  var phrases = ['Workday integrations.','custom Extend applications.','PRISM analytics dashboards.','payroll & benefits systems.','enterprise HR solutions.'];
+  var phrases = ['AI-augmented HR infrastructure.','Workday MCP servers for Claude AI.','Workday integrations at scale.','PRISM analytics dashboards.','enterprise payroll systems.','custom Extend applications.'];
   var pi = 0, ci = 0, del = false, typedEl = document.getElementById('typed-text');
   (function typeLoop() {
     var cur = phrases[pi];
@@ -1198,21 +1202,21 @@
       var low = q.toLowerCase();
       setTimeout(function() {
         if (match(low, ['experience','work','career','year','how long'])) {
-          addBotMsg("Krishna has <strong>10+ years</strong> of Workday experience across 5 enterprise companies: <strong>Lyft, Gilead Health Sciences, USAA, NCI Inc,</strong> and <strong>Dropbox</strong>. He's currently a Sr. Workday Systems Engineer at Lyft (since Jan 2020).");
+          addBotMsg("Krishna has <strong>11+ years</strong> of Workday experience across 5 enterprise companies: <strong>Lyft, Gilead Sciences, USAA, NCI Information Systems,</strong> and <strong>Dropbox</strong>. He's currently a Senior Workday Systems Engineer at Lyft (since Jan 2020), where he pioneered a <strong>production MCP server connecting Claude AI to Workday</strong>.");
         } else if (match(low, ['company','companies','where','employer','worked at','lyft','gilead','usaa','dropbox','nci'])) {
-          addBotMsg("<strong>Companies:</strong><br>&#8226; <strong>Lyft</strong> — Sr. Systems Engineer (2020–Present)<br>&#8226; <strong>Gilead</strong> — Sr. Techno-Functional Consultant (2017–2020)<br>&#8226; <strong>USAA</strong> — Sr. Consultant (2015–2017)<br>&#8226; <strong>NCI Inc</strong> — Technical Consultant (2015)<br>&#8226; <strong>Dropbox</strong> — Integration Developer (2014–2015)");
+          addBotMsg("<strong>Companies:</strong><br>&#8226; <strong>Lyft</strong> — Senior Workday Systems Engineer (2020–Present)<br>&#8226; <strong>Gilead Sciences</strong> — Sr. Integration Developer (2017–2020)<br>&#8226; <strong>USAA</strong> — Integration Development Lead (2015–2017)<br>&#8226; <strong>NCI Information Systems</strong> — Techno-Functional Consultant (2015–2016)<br>&#8226; <strong>Dropbox</strong> — Implementation Consultant (2015)");
         } else if (match(low, ['skill','expert','specializ','know','good at','what can','capable'])) {
-          addBotMsg("Krishna's core expertise:<br>&#8226; <strong>Workday Studio</strong> — SOAP/REST integrations<br>&#8226; <strong>Workday Extend</strong> — Custom applications<br>&#8226; <strong>PRISM Analytics</strong> — Dashboards & datasets<br>&#8226; <strong>Payroll & Benefits</strong> — ADP, PECI/PICOF<br>&#8226; <strong>HCM</strong> — End-to-end implementations<br>&#8226; <strong>Security Admin</strong> — Groups & policies<br>&#8226; <strong>Reporting</strong> — Advanced, composite, BIRT, RAAS");
+          addBotMsg("Krishna's core expertise:<br>&#8226; <strong>AI & MCP</strong> — Production MCP servers, Claude AI, Anthropic SDK<br>&#8226; <strong>Workday Studio</strong> — SOAP/REST integrations<br>&#8226; <strong>TypeScript/Node.js</strong> — MCP servers, Jira automation<br>&#8226; <strong>PRISM Analytics</strong> — Dashboards & datasets<br>&#8226; <strong>Payroll</strong> — ADP, Dayforce, Safeguard<br>&#8226; <strong>Security & Compliance</strong> — SOX, audit-readiness<br>&#8226; <strong>Reporting</strong> — Advanced, composite, BIRT, RAAS");
         } else if (match(low, ['education','study','degree','university','college','school'])) {
           addBotMsg("<strong>Education:</strong><br>&#8226; <strong>MS in Electrical Engineering</strong> — Texas A&M University, Kingsville, TX (2014)<br>&#8226; <strong>BE in Electronics & Communication</strong> — KL University, Guntur, India (2013)");
         } else if (match(low, ['contact','email','phone','reach','linkedin','github','hire'])) {
-          addBotMsg("You can reach Krishna at:<br>&#8226; Email: <a href='mailto:krishnac.gutta@gmail.com'>krishnac.gutta@gmail.com</a><br>&#8226; Phone: <a href='tel:+17169579206'>+1 (716) 957-9206</a><br>&#8226; LinkedIn: <a href='https://www.linkedin.com/in/krishna-gutta/' target='_blank'>krishna-gutta</a><br>&#8226; GitHub: <a href='https://github.com/gkchaitanya1503' target='_blank'>gkchaitanya1503</a>");
+          addBotMsg("You can reach Krishna at:<br>&#8226; Email: <a href='mailto:krishnac.gutta@gmail.com'>krishnac.gutta@gmail.com</a><br>&#8226; Phone: <a href='tel:+17209602821'>+1 (720) 960-2821</a><br>&#8226; LinkedIn: <a href='https://www.linkedin.com/in/krishna-gutta/' target='_blank'>krishna-gutta</a><br>&#8226; GitHub: <a href='https://github.com/gkchaitanya1503' target='_blank'>gkchaitanya1503</a>");
         } else if (match(low, ['extend','app','application','custom app'])) {
-          addBotMsg("At <strong>Lyft</strong>, Krishna built <strong>3 custom Extend applications</strong>:<br>&#8226; <strong>Check-in Hub</strong> — Performance management for all employees<br>&#8226; <strong>RSU Tax Election</strong> — Annual self-service stock tax selection<br>&#8226; <strong>Return to Office</strong> — Vaccine verification and HR approval<br><br>He uses Fieldsets, task flows, orchestrations, and On Change events.");
+          addBotMsg("At <strong>Lyft</strong>, Krishna built <strong>custom Extend applications</strong> including performance management apps. But his biggest innovation is the <strong>production MCP server</strong> — 27 Workday tools exposed to Claude AI via OAuth 2.0 PKCE and Okta SSO. He also built a <strong>Jira-Workday automation system</strong> using TypeScript MCP servers and Claude's API.");
         } else if (match(low, ['prism','dashboard','analytics','report'])) {
           addBotMsg("Krishna built <strong>Prism Data sets</strong> at Lyft for total compensation dashboards covering Base Pay, OTP, Bonuses, and Stock Vesting. He also delivers advanced, composite, and matrix reports using BIRT and RAAS across multiple companies.");
         } else if (match(low, ['integration','studio','soap','rest'])) {
-          addBotMsg("Krishna has delivered <strong>50+ integrations</strong> using Workday Studio, including:<br>&#8226; Schwab stock vesting, GSuite, Okta (Lyft)<br>&#8226; ADP Payforce, Field Glass, Photo load (Gilead)<br>&#8226; Payroll deductions, absence inputs (USAA)<br>&#8226; Greenhouse ATS bidirectional sync (Dropbox)<br>&#8226; Liberty Mutual, Prudential, UHC (NCI)");
+          addBotMsg("Krishna has delivered <strong>50+ integrations</strong> using Workday Studio, including:<br>&#8226; <strong>MCP Server</strong> — 27 Workday tools for Claude AI (Lyft)<br>&#8226; Dayforce payroll migration across US, Canada & Mexico (Lyft)<br>&#8226; GoodTime, Checkr, Rightway, Anaplan, Schwab (Lyft)<br>&#8226; Safeguard payroll, Fieldglass VMS (Gilead)<br>&#8226; Silanis E-Sign, ADP, Xerox (USAA)<br>&#8226; Liberty Mutual, Prudential, UHC (NCI)");
         } else if (match(low, ['certif','license','credential','pro ','workday pro','97'])) {
           addBotMsg("<strong>Certifications:</strong><br>&#8226; <strong>Workday Advanced Studio Pro</strong> — 97% score! (2019)<br>&#8226; <strong>Workday Pro Studio</strong> (2020)<br>&#8226; <strong>PRISM Analytics</strong> (2020)<br>&#8226; <strong>Workday Extend</strong> (Multiple)<br>&#8226; <strong>Workato Agentic AI Basics</strong> (2025)<br>&#8226; <strong>Workato Foundations Level 1</strong> (2025)<br><br>6+ industry-recognized credentials.");
         } else if (match(low, ['article','publish','write','blog','thought','alexa','voice'])) {
@@ -1221,10 +1225,12 @@
           addBotMsg("<strong>Awards:</strong><br>&#8226; <strong>Best Student Award</strong> — KL University (2007)<br>&#8226; <strong>Workday Advanced Studio Pro</strong> — scored <strong>97%</strong> (top percentile)<br><br>Krishna was also a <strong>Core Team Member at VR1</strong>, organizing engineering workshops (2008–2015).");
         } else if (match(low, ['volunteer','community','workshop','vr1'])) {
           addBotMsg("Krishna served as a <strong>Core Team Member at VR1</strong> (2008–2015), organizing engineering workshops focused on developing creative capabilities and fostering innovation in students.");
-        } else if (match(low, ['location','where','live','based','city','denver','colorado'])) {
-          addBotMsg("Krishna is based in <strong>Denver, Colorado</strong>.");
+        } else if (match(low, ['location','where','live','based','city','denver','colorado','boulder'])) {
+          addBotMsg("Krishna is based in <strong>Boulder, Colorado</strong>.");
+        } else if (match(low, ['mcp','model context','protocol','claude','anthropic','27 tool'])) {
+          addBotMsg("Krishna pioneered <strong>AI-augmented HR infrastructure</strong> at Lyft:<br>&#8226; Built a production <strong>Model Context Protocol (MCP) server</strong> exposing <strong>27 Workday HR tools</strong> to Claude AI<br>&#8226; Uses <strong>OAuth 2.0 PKCE</strong> and <strong>Okta SSO</strong> for secure authentication<br>&#8226; Enables employees to self-serve compensation, PTO, org structure, and inbox approvals in plain English<br>&#8226; Also built a <strong>Jira-Workday automation</strong> using TypeScript MCP servers and Claude's API");
         } else if (match(low, ['workato','automation','agentic','ai '])) {
-          addBotMsg("Krishna recently earned <strong>Workato</strong> certifications:<br>&#8226; <strong>Agentic AI Basics</strong> (Dec 2025)<br>&#8226; <strong>Foundations Level 1</strong> (Dec 2025)<br><br>He's expanding into AI-powered automation alongside his Workday expertise.");
+          addBotMsg("Krishna is at the forefront of <strong>AI + HR automation</strong>:<br>&#8226; Built a production <strong>MCP server</strong> connecting Claude AI to Workday at Lyft<br>&#8226; <strong>Workato Agentic AI Basics</strong> certification (Dec 2025)<br>&#8226; <strong>Workato Foundations Level 1</strong> certification (Dec 2025)<br>&#8226; Developed Jira-Workday automation using <strong>TypeScript MCP servers</strong> and <strong>Claude's API</strong>");
         } else if (match(low, ['follower','linkedin follow','network','connection'])) {
           addBotMsg("Krishna has <strong>8,000+ LinkedIn followers</strong> and <strong>500+ connections</strong>. He's an active voice in the Workday community, sharing articles and insights. Connect at <a href='https://www.linkedin.com/in/krishna-gutta/' target='_blank'>linkedin.com/in/krishna-gutta</a>.");
         } else if (match(low, ['hello','hi','hey','greet'])) {

--- a/styles.css
+++ b/styles.css
@@ -605,6 +605,38 @@ img { max-width: 100%; height: auto; }
   line-height: 1.6;
 }
 
+/* Featured skill card (AI/MCP) */
+.skill-card-featured {
+  border: 2px solid var(--primary);
+  background: linear-gradient(135deg, rgba(79,70,229,0.04), rgba(6,182,212,0.04));
+  position: relative;
+}
+
+.skill-card-featured::before {
+  content: 'NEW';
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: var(--white);
+  font-size: 0.6rem;
+  font-weight: 800;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  letter-spacing: 1px;
+}
+
+/* Highlighted tool items (AI tools) */
+.tool-highlight {
+  border: 2px solid var(--primary) !important;
+  background: linear-gradient(135deg, rgba(79,70,229,0.08), rgba(6,182,212,0.08)) !important;
+  font-weight: 600;
+}
+
+.tool-highlight i {
+  color: var(--primary) !important;
+}
+
 /* ========================================
    EXPERIENCE / TIMELINE
    ======================================== */
@@ -1034,6 +1066,20 @@ img { max-width: 100%; height: auto; }
   height: 4px;
   background: linear-gradient(90deg, #0a66c2, var(--primary));
   border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.pub-card-featured {
+  border: 2px solid var(--primary);
+  background: linear-gradient(135deg, rgba(79,70,229,0.04), rgba(6,182,212,0.04));
+}
+
+.pub-card-featured::before {
+  background: linear-gradient(90deg, var(--primary), var(--accent));
+  height: 5px;
+}
+
+.pub-card-featured .pub-icon i {
+  color: var(--primary);
 }
 
 .pub-card:hover {
@@ -1830,6 +1876,9 @@ body.dark-mode .cert-badge { background: linear-gradient(135deg, rgba(79,70,229,
 
 body.dark-mode #publications { background: #0f172a; }
 body.dark-mode .pub-card { background: #1e293b; border-color: rgba(255,255,255,0.06); }
+body.dark-mode .pub-card-featured { background: linear-gradient(135deg, rgba(79,70,229,0.12), #1e293b); border-color: var(--primary); }
+body.dark-mode .skill-card-featured { background: linear-gradient(135deg, rgba(79,70,229,0.12), #1e293b); border-color: var(--primary); }
+body.dark-mode .tool-highlight { background: linear-gradient(135deg, rgba(79,70,229,0.15), rgba(6,182,212,0.15)) !important; border-color: var(--primary) !important; }
 body.dark-mode .pub-card h4 { color: #f1f5f9; }
 body.dark-mode .pub-card p { color: #cbd5e1; }
 body.dark-mode .pub-meta { color: #94a3b8; }


### PR DESCRIPTION
… content

- Update professional identity to AI-Augmented Workday Engineer
- Add production MCP server (27 Workday tools for Claude AI) as headline achievement
- Update all experience sections with latest resume content (Lyft MCP server, Dayforce migration, Free Now M&A, Jira-Workday automation, etc.)
- Update contact info: Boulder CO, new phone number
- Add AI/MCP as featured skill card and highlighted tool items
- Update Tools section: TypeScript, Node.js, OAuth 2.0 PKCE, Anthropic SDK
- Update impact stats: 11+ years, 27 MCP tools
- Add MCP-focused publication card and testimonial
- Update AI chatbot with MCP/AI responses and suggestions
- Fix duplicate Google Analytics tag
- Add CSS for featured/highlighted cards with dark mode support

https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q