### PR TITLE
Add Featured Projects section (MCP server front and center)

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,9 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ml-auto">
+          <li class="nav-item"><a class="nav-link" href="#projects">Projects</a></li>
           <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
           <li class="nav-item"><a class="nav-link" href="#impact">Impact</a></li>
-          <li class="nav-item"><a class="nav-link" href="#tools">Tools</a></li>
           <li class="nav-item"><a class="nav-link" href="#skills">Expertise</a></li>
           <li class="nav-item"><a class="nav-link" href="#experience">Experience</a></li>
           <li class="nav-item"><a class="nav-link" href="#education">Education</a></li>
@@ -139,13 +139,20 @@
           <span class="typed-cursor">|</span>
         </div>
         <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Boulder, CO</p>
-        <p class="hero-text">11+ years transforming enterprise HR ecosystems through Workday — now pioneering AI-augmented HR infrastructure with a production MCP server exposing 27 Workday tools to Claude AI at Lyft.</p>
+        <p class="hero-text">11+ years transforming enterprise HR ecosystems through Workday — now pioneering AI-augmented HR infrastructure with a production MCP server exposing 27 Workday tools to Claude AI.</p>
+        <a href="#projects" class="hero-build-badge">
+          <span class="hero-build-pulse"></span>
+          <i class="fas fa-rocket mr-2"></i>
+          <span class="hero-build-label">Latest build:</span>
+          <span class="hero-build-name">Workday MCP Server</span>
+          <i class="fas fa-arrow-right ml-2"></i>
+        </a>
         <div class="hero-cta">
-          <a href="#contact" class="btn hero-btn-primary">
-            <i class="fas fa-paper-plane mr-2"></i>Let's Connect
+          <a href="#projects" class="btn hero-btn-primary">
+            <i class="fas fa-code mr-2"></i>View Projects
           </a>
-          <a href="#experience" class="btn hero-btn-outline">
-            <i class="fas fa-briefcase mr-2"></i>View My Work
+          <a href="#contact" class="btn hero-btn-outline">
+            <i class="fas fa-paper-plane mr-2"></i>Let's Connect
           </a>
           <a href="Krishna_Gutta_Resume 2026.docx" download class="btn hero-btn-ghost">
             <i class="fas fa-download mr-2"></i>Resume
@@ -170,10 +177,143 @@
   </div>
 </section>
 
-<!-- Wave Divider: Hero → About -->
+<!-- Wave Divider: Hero → Projects -->
 <div class="wave-divider wave-navy-to-white">
   <svg viewBox="0 0 1440 120" preserveAspectRatio="none">
     <path d="M0,64 C360,120 720,0 1080,64 C1260,96 1380,80 1440,64 L1440,120 L0,120 Z" fill="currentColor"/>
+  </svg>
+</div>
+
+<!-- Featured Projects Section -->
+<section id="projects">
+  <div class="container">
+    <h2 class="section-heading text-center" data-aos="fade-up"><i class="fas fa-code-branch mr-2"></i>Featured Projects</h2>
+    <div class="heading-underline" data-aos="fade-up" data-aos-delay="100"></div>
+    <p class="section-subtitle text-center" data-aos="fade-up" data-aos-delay="150">Open-source MCP servers, integrations, and production tools — bridging Workday and AI</p>
+
+    <div class="row mt-5">
+      <!-- Workday MCP / OAuth PKCE -->
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="100">
+        <a href="https://github.com/gkchaitanya1503/workday-oauth-poc" target="_blank" rel="noopener noreferrer" class="project-card-link">
+          <div class="project-card project-card-featured">
+            <div class="project-card-header">
+              <div class="project-icon"><i class="fas fa-robot"></i></div>
+              <div class="project-badges">
+                <span class="project-status project-status-live"><span class="status-pulse"></span>Live</span>
+                <span class="project-star"><i class="fas fa-star"></i>Flagship</span>
+              </div>
+            </div>
+            <h3 class="project-title">Workday MCP Server</h3>
+            <p class="project-tagline">27 Workday HR tools exposed to Claude AI via OAuth 2.0 PKCE</p>
+            <p class="project-description">Production-grade Model Context Protocol server that lets Claude AI query Workday for compensation, PTO, org structure, and inbox approvals in plain English. Employee-scoped tokens with Okta SSO and functional-area scoping.</p>
+            <div class="project-tech-stack">
+              <span class="tech-badge">MCP</span>
+              <span class="tech-badge">Claude AI</span>
+              <span class="tech-badge">OAuth 2.0 PKCE</span>
+              <span class="tech-badge">Node.js</span>
+              <span class="tech-badge">JavaScript</span>
+              <span class="tech-badge">Okta SSO</span>
+            </div>
+            <div class="project-footer">
+              <span class="project-meta"><i class="fab fa-github mr-1"></i>gkchaitanya1503/workday-oauth-poc</span>
+              <span class="project-cta">View Code <i class="fas fa-arrow-right"></i></span>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Workday Studio MCP (coming soon) -->
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="200">
+        <div class="project-card project-card-upcoming">
+          <div class="project-card-header">
+            <div class="project-icon"><i class="fas fa-code"></i></div>
+            <div class="project-badges">
+              <span class="project-status project-status-building"><i class="fas fa-hammer mr-1"></i>In Progress</span>
+            </div>
+          </div>
+          <h3 class="project-title">Workday Studio MCP</h3>
+          <p class="project-tagline">Bringing Claude AI into the Workday Studio developer workflow</p>
+          <p class="project-description">Next-gen MCP server that exposes Workday Studio integration development to Claude — write, test, and deploy Studio integrations with AI assistance. Currently in active development.</p>
+          <div class="project-tech-stack">
+            <span class="tech-badge">MCP</span>
+            <span class="tech-badge">Claude AI</span>
+            <span class="tech-badge">TypeScript</span>
+            <span class="tech-badge">Workday Studio</span>
+            <span class="tech-badge">XSLT</span>
+          </div>
+          <div class="project-footer">
+            <span class="project-meta"><i class="fas fa-clock mr-1"></i>Coming soon</span>
+            <span class="project-cta project-cta-disabled">Stay tuned <i class="fas fa-hourglass-half"></i></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Jira-Workday Automation -->
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="300">
+        <div class="project-card">
+          <div class="project-card-header">
+            <div class="project-icon"><i class="fas fa-bolt"></i></div>
+            <div class="project-badges">
+              <span class="project-status project-status-live"><span class="status-pulse"></span>In Production</span>
+            </div>
+          </div>
+          <h3 class="project-title">Jira &times; Workday AI Automation</h3>
+          <p class="project-tagline">BOT commands in Jira tickets that query live Workday data via Claude</p>
+          <p class="project-description">TypeScript MCP server that routes BOT: commands from Jira tickets to Claude's API, which then pulls employee context from Workday in real time. Built to accelerate ticket triage for HR tech support.</p>
+          <div class="project-tech-stack">
+            <span class="tech-badge">TypeScript</span>
+            <span class="tech-badge">Claude API</span>
+            <span class="tech-badge">Jira Automation</span>
+            <span class="tech-badge">Workday REST</span>
+          </div>
+          <div class="project-footer">
+            <span class="project-meta"><i class="fas fa-building mr-1"></i>Lyft Production</span>
+            <span class="project-cta project-cta-disabled">Internal <i class="fas fa-lock"></i></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- This Portfolio -->
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="400">
+        <a href="https://github.com/gkchaitanya1503/myportfolio" target="_blank" rel="noopener noreferrer" class="project-card-link">
+          <div class="project-card">
+            <div class="project-card-header">
+              <div class="project-icon"><i class="fas fa-globe"></i></div>
+              <div class="project-badges">
+                <span class="project-status project-status-live"><span class="status-pulse"></span>Live</span>
+              </div>
+            </div>
+            <h3 class="project-title">This Portfolio</h3>
+            <p class="project-tagline">Hand-crafted, AI-first — because your site should reflect your craft</p>
+            <p class="project-description">Built with vanilla HTML, CSS, and JavaScript — no framework overhead. Features an AI chatbot trained on my experience, Google Analytics instrumentation, and an accessibility-first design.</p>
+            <div class="project-tech-stack">
+              <span class="tech-badge">HTML5</span>
+              <span class="tech-badge">CSS3</span>
+              <span class="tech-badge">JavaScript</span>
+              <span class="tech-badge">Bootstrap</span>
+              <span class="tech-badge">GA4</span>
+            </div>
+            <div class="project-footer">
+              <span class="project-meta"><i class="fab fa-github mr-1"></i>gkchaitanya1503/myportfolio</span>
+              <span class="project-cta">View Code <i class="fas fa-arrow-right"></i></span>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+
+    <div class="text-center mt-4" data-aos="fade-up">
+      <a href="https://github.com/gkchaitanya1503" target="_blank" rel="noopener noreferrer" class="btn projects-more-btn">
+        <i class="fab fa-github mr-2"></i>See all on GitHub
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- Wave Divider: Projects → About -->
+<div class="wave-divider wave-white-to-light">
+  <svg viewBox="0 0 1440 120" preserveAspectRatio="none">
+    <path d="M0,40 C360,96 720,0 1080,64 C1260,96 1380,80 1440,64 L1440,120 L0,120 Z" fill="currentColor"/>
   </svg>
 </div>
 
@@ -871,6 +1011,7 @@
     </div>
     <div id="chat-suggestions">
       <button class="chat-suggestion" data-q="Tell me about the MCP server you built">MCP Server</button>
+      <button class="chat-suggestion" data-q="Show me your GitHub projects">Projects</button>
       <button class="chat-suggestion" data-q="What is your Workday experience?">Workday experience</button>
       <button class="chat-suggestion" data-q="What companies have you worked at?">Companies</button>
       <button class="chat-suggestion" data-q="What are your skills?">Skills</button>
@@ -1226,7 +1367,9 @@
         } else if (match(low, ['location','where','live','based','city','denver','colorado','boulder'])) {
           addBotMsg("Krishna is based in <strong>Boulder, Colorado</strong>.");
         } else if (match(low, ['mcp','model context','protocol','claude','anthropic','27 tool'])) {
-          addBotMsg("Krishna pioneered <strong>AI-augmented HR infrastructure</strong> at Lyft:<br>&#8226; Built a production <strong>Model Context Protocol (MCP) server</strong> exposing <strong>27 Workday HR tools</strong> to Claude AI<br>&#8226; Uses <strong>OAuth 2.0 PKCE</strong> and <strong>Okta SSO</strong> for secure authentication<br>&#8226; Enables employees to self-serve compensation, PTO, org structure, and inbox approvals in plain English<br>&#8226; Also built a <strong>Jira-Workday automation</strong> using TypeScript MCP servers and Claude's API");
+          addBotMsg("Krishna pioneered <strong>AI-augmented HR infrastructure</strong>:<br>&#8226; Built a production <strong>Model Context Protocol (MCP) server</strong> exposing <strong>27 Workday HR tools</strong> to Claude AI — <a href='https://github.com/gkchaitanya1503/workday-oauth-poc' target='_blank'>view on GitHub</a><br>&#8226; Uses <strong>OAuth 2.0 PKCE</strong> and <strong>Okta SSO</strong> for secure authentication<br>&#8226; Enables employees to self-serve comp, PTO, org structure, and inbox approvals in plain English<br>&#8226; Also built a <strong>Jira-Workday automation</strong> using TypeScript MCP servers and Claude's API<br>&#8226; <strong>Workday Studio MCP</strong> in active development");
+        } else if (match(low, ['project','github','repo','open source','code'])) {
+          addBotMsg("Check out Krishna's featured projects:<br>&#8226; <strong>Workday MCP Server</strong> — 27 Workday tools for Claude AI (<a href='https://github.com/gkchaitanya1503/workday-oauth-poc' target='_blank'>GitHub</a>)<br>&#8226; <strong>Workday Studio MCP</strong> — In progress, bringing Claude into Studio dev workflows<br>&#8226; <strong>Jira x Workday Automation</strong> — BOT commands routed to Claude + Workday<br>&#8226; <strong>This Portfolio</strong> (<a href='https://github.com/gkchaitanya1503/myportfolio' target='_blank'>GitHub</a>)<br><br>All repos at <a href='https://github.com/gkchaitanya1503' target='_blank'>github.com/gkchaitanya1503</a>");
         } else if (match(low, ['workato','automation','agentic','ai '])) {
           addBotMsg("Krishna is at the forefront of <strong>AI + HR automation</strong>:<br>&#8226; Built a production <strong>MCP server</strong> connecting Claude AI to Workday at Lyft<br>&#8226; <strong>Workato Agentic AI Basics</strong> certification (Dec 2025)<br>&#8226; <strong>Workato Foundations Level 1</strong> certification (Dec 2025)<br>&#8226; Developed Jira-Workday automation using <strong>TypeScript MCP servers</strong> and <strong>Claude's API</strong>");
         } else if (match(low, ['follower','linkedin follow','network','connection'])) {

--- a/styles.css
+++ b/styles.css
@@ -638,6 +638,370 @@ img { max-width: 100%; height: auto; }
 }
 
 /* ========================================
+   HERO BUILD BADGE
+   ======================================== */
+.hero-build-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(79, 70, 229, 0.15);
+  border: 1px solid rgba(79, 70, 229, 0.35);
+  color: var(--white) !important;
+  padding: 0.55rem 1rem 0.55rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-decoration: none !important;
+  margin-bottom: 1.75rem;
+  transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.hero-build-badge:hover {
+  background: rgba(79, 70, 229, 0.28);
+  border-color: rgba(6, 182, 212, 0.6);
+  transform: translateY(-2px);
+  color: var(--white) !important;
+  text-decoration: none !important;
+}
+
+.hero-build-badge .hero-build-label {
+  color: rgba(255, 255, 255, 0.7);
+  margin-right: 0.15rem;
+}
+
+.hero-build-badge .hero-build-name {
+  color: var(--accent-light);
+  font-weight: 700;
+}
+
+.hero-build-badge i.fa-rocket {
+  color: var(--accent-light);
+}
+
+.hero-build-pulse {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7);
+  animation: build-pulse 2s infinite;
+  margin-right: 0.25rem;
+}
+
+@keyframes build-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7); }
+  70% { box-shadow: 0 0 0 10px rgba(16, 185, 129, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+
+/* ========================================
+   FEATURED PROJECTS
+   ======================================== */
+#projects {
+  padding: 6rem 0 7rem;
+  background: var(--white);
+  position: relative;
+}
+
+.project-card-link {
+  display: block;
+  text-decoration: none !important;
+  color: inherit;
+  height: 100%;
+}
+
+.project-card {
+  background: var(--bg-light);
+  border-radius: var(--radius);
+  padding: 1.75rem 1.75rem 1.5rem;
+  height: 100%;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, var(--primary), var(--accent));
+  opacity: 0.35;
+  transition: opacity 0.35s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
+  border-color: rgba(79, 70, 229, 0.2);
+}
+
+.project-card:hover::before {
+  opacity: 1;
+}
+
+.project-card-featured {
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.04), rgba(6, 182, 212, 0.05));
+  border: 2px solid rgba(79, 70, 229, 0.25);
+}
+
+.project-card-featured::before {
+  height: 5px;
+  opacity: 1;
+}
+
+.project-card-upcoming {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--bg-light),
+    var(--bg-light) 14px,
+    rgba(79, 70, 229, 0.025) 14px,
+    rgba(79, 70, 229, 0.025) 28px
+  );
+  border-style: dashed;
+  border-color: rgba(79, 70, 229, 0.3);
+}
+
+.project-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+.project-icon {
+  width: 54px;
+  height: 54px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--white);
+  font-size: 1.4rem;
+  flex-shrink: 0;
+  box-shadow: 0 6px 20px rgba(79, 70, 229, 0.25);
+}
+
+.project-badges {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.project-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+}
+
+.project-status-live {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.status-pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.6);
+  animation: build-pulse 2s infinite;
+}
+
+.project-status-building {
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+}
+
+.project-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: var(--white);
+}
+
+.project-title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--navy);
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.3px;
+}
+
+.project-tagline {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--primary);
+  margin-bottom: 0.85rem;
+  line-height: 1.4;
+}
+
+.project-description {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+  margin-bottom: 1.25rem;
+  flex-grow: 1;
+}
+
+.project-tech-stack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1.25rem;
+}
+
+.tech-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--primary-dark);
+  background: rgba(79, 70, 229, 0.08);
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  letter-spacing: 0.2px;
+}
+
+.project-card-featured .tech-badge {
+  background: rgba(79, 70, 229, 0.12);
+}
+
+.project-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  font-size: 0.8rem;
+}
+
+.project-meta {
+  color: var(--gray);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+}
+
+.project-cta {
+  color: var(--primary);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: gap 0.3s ease;
+}
+
+.project-card-link:hover .project-cta {
+  gap: 0.7rem;
+}
+
+.project-cta-disabled {
+  color: var(--gray-light);
+  font-weight: 600;
+}
+
+.projects-more-btn {
+  background: var(--navy);
+  color: var(--white) !important;
+  padding: 0.8rem 1.8rem;
+  font-weight: 600;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+  font-size: 0.92rem;
+  text-decoration: none !important;
+}
+
+.projects-more-btn:hover {
+  background: var(--primary);
+  transform: translateY(-3px);
+  box-shadow: 0 8px 25px rgba(79, 70, 229, 0.3);
+  color: var(--white) !important;
+}
+
+/* Wave divider variant */
+.wave-white-to-light {
+  color: var(--bg-light);
+}
+body:not(.dark-mode) .wave-white-to-light { color: var(--bg-light); }
+
+/* Dark mode for projects */
+body.dark-mode #projects { background: #0f172a; }
+body.dark-mode .project-card {
+  background: #1e293b;
+  border-color: rgba(255, 255, 255, 0.06);
+}
+body.dark-mode .project-card-featured {
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), #1e293b);
+  border-color: var(--primary);
+}
+body.dark-mode .project-card-upcoming {
+  background: repeating-linear-gradient(
+    45deg,
+    #1e293b,
+    #1e293b 14px,
+    rgba(79, 70, 229, 0.08) 14px,
+    rgba(79, 70, 229, 0.08) 28px
+  );
+  border-color: rgba(79, 70, 229, 0.4);
+}
+body.dark-mode .project-title { color: #f1f5f9; }
+body.dark-mode .project-description { color: #cbd5e1; }
+body.dark-mode .project-tagline { color: #818cf8; }
+body.dark-mode .tech-badge {
+  color: #c7d2fe;
+  background: rgba(79, 70, 229, 0.2);
+}
+body.dark-mode .project-footer {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+body.dark-mode .project-meta { color: #94a3b8; }
+body.dark-mode .project-cta { color: #818cf8; }
+body.dark-mode .project-status-live {
+  background: rgba(16, 185, 129, 0.15);
+  color: #34d399;
+}
+body.dark-mode .project-status-building {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+}
+body.dark-mode .projects-more-btn {
+  background: #334155;
+}
+body.dark-mode .projects-more-btn:hover {
+  background: var(--primary);
+}
+
+/* Responsive */
+@media (max-width: 767.98px) {
+  .project-card { padding: 1.4rem; }
+  .project-title { font-size: 1.15rem; }
+  .hero-build-badge { font-size: 0.75rem; padding: 0.45rem 0.85rem; }
+}
+
+/* ========================================
    EXPERIENCE / TIMELINE
    ======================================== */
 #experience {


### PR DESCRIPTION
## Summary
New **Featured Projects** section placed right after the Hero so visitors see Krishna's best work within the first scroll.

### What's added
- **Workday MCP Server** — flagship card, links to [workday-oauth-poc](https://github.com/gkchaitanya1503/workday-oauth-poc)
- **Workday Studio MCP** — "In Progress" card to build anticipation
- **Jira x Workday AI Automation** — production work at Lyft
- **This Portfolio** — links to the myportfolio repo
- Hero pulse badge ("Latest build: Workday MCP Server") for instant visibility
- Nav reordered so **Projects** is the first link
- Primary hero CTA changed to "View Projects"
- Chatbot: new Projects response + suggestion pill
- Full dark mode + responsive support

## Test plan
- [ ] Projects section renders with 4 cards in 2x2 grid on desktop
- [ ] Featured card (MCP server) has distinct gradient/border
- [ ] "In Progress" card shows dashed border + diagonal stripe pattern
- [ ] Hero badge pulses and scrolls to #projects on click
- [ ] GitHub links open in new tab
- [ ] Dark mode styling looks correct
- [ ] Mobile: cards stack, tech badges wrap cleanly

https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q