### PR TITLE
Add Workday Community MCP and Integration Monitor projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
       "address": {"@type": "PostalAddress", "addressLocality": "Boulder", "addressRegion": "CO", "addressCountry": "US"},
       "sameAs": [
         "https://www.linkedin.com/in/krishna-gutta/",
+        "https://github.com/krishnagutta",
         "https://github.com/gkchaitanya1503"
       ],
       "alumniOf": [
@@ -252,8 +253,66 @@
         </a>
       </div>
 
-      <!-- Jira-Workday Automation -->
+      <!-- Workday Community MCP -->
       <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="300">
+        <a href="https://github.com/krishnagutta/workday-community-mcp" target="_blank" rel="noopener noreferrer" class="project-card-link">
+          <div class="project-card project-card-featured">
+            <div class="project-card-header">
+              <div class="project-icon"><i class="fas fa-search"></i></div>
+              <div class="project-badges">
+                <span class="project-status project-status-live"><span class="status-pulse"></span>Live</span>
+                <span class="project-star"><i class="fas fa-fire"></i>New</span>
+              </div>
+            </div>
+            <h3 class="project-title">Workday Community MCP</h3>
+            <p class="project-tagline">Search Workday Community docs, release notes &amp; KB articles from Claude</p>
+            <p class="project-description">MCP server that exposes Workday Community and Resource Center search to Claude via the Coveo API. Includes release notes search, Salesforce KB access, full article retrieval, and auto-refreshing JWT tokens via Playwright.</p>
+            <div class="project-tech-stack">
+              <span class="tech-badge">MCP</span>
+              <span class="tech-badge">Python</span>
+              <span class="tech-badge">Coveo API</span>
+              <span class="tech-badge">Playwright</span>
+              <span class="tech-badge">FastMCP</span>
+              <span class="tech-badge">MIT</span>
+            </div>
+            <div class="project-footer">
+              <span class="project-meta"><i class="fab fa-github mr-1"></i>krishnagutta/workday-community-mcp</span>
+              <span class="project-cta">View Code <i class="fas fa-arrow-right"></i></span>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Integration Monitor -->
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="400">
+        <a href="https://github.com/krishnagutta/integration-monitor" target="_blank" rel="noopener noreferrer" class="project-card-link">
+          <div class="project-card">
+            <div class="project-card-header">
+              <div class="project-icon"><i class="fas fa-heartbeat"></i></div>
+              <div class="project-badges">
+                <span class="project-status project-status-live"><span class="status-pulse"></span>In Production</span>
+              </div>
+            </div>
+            <h3 class="project-title">Integration Monitor Agent</h3>
+            <p class="project-tagline">AI-powered Workday integration monitoring with Slack digests</p>
+            <p class="project-description">Automated monitoring agent that scans Jira for integration failures, classifies errors with Claude AI, takes autonomous action, and posts digest summaries to Slack every 30 minutes via GitHub Actions.</p>
+            <div class="project-tech-stack">
+              <span class="tech-badge">Python</span>
+              <span class="tech-badge">Claude API</span>
+              <span class="tech-badge">Jira REST</span>
+              <span class="tech-badge">Slack Bot</span>
+              <span class="tech-badge">GitHub Actions</span>
+            </div>
+            <div class="project-footer">
+              <span class="project-meta"><i class="fab fa-github mr-1"></i>krishnagutta/integration-monitor</span>
+              <span class="project-cta">View Code <i class="fas fa-arrow-right"></i></span>
+            </div>
+          </div>
+        </a>
+      </div>
+
+      <!-- Jira-Workday Automation -->
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="500">
         <div class="project-card">
           <div class="project-card-header">
             <div class="project-icon"><i class="fas fa-bolt"></i></div>
@@ -278,7 +337,7 @@
       </div>
 
       <!-- This Portfolio -->
-      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="400">
+      <div class="col-lg-6 mb-4" data-aos="fade-up" data-aos-delay="600">
         <a href="https://github.com/gkchaitanya1503/myportfolio" target="_blank" rel="noopener noreferrer" class="project-card-link">
           <div class="project-card">
             <div class="project-card-header">
@@ -289,7 +348,7 @@
             </div>
             <h3 class="project-title">This Portfolio</h3>
             <p class="project-tagline">Hand-crafted, AI-first — because your site should reflect your craft</p>
-            <p class="project-description">Built with vanilla HTML, CSS, and JavaScript — no framework overhead. Features an AI chatbot trained on my experience, Google Analytics instrumentation, and an accessibility-first design.</p>
+            <p class="project-description">Built with vanilla HTML, CSS, and JavaScript — no framework overhead. Features an AI chatbot, Google Analytics instrumentation, and an accessibility-first design.</p>
             <div class="project-tech-stack">
               <span class="tech-badge">HTML5</span>
               <span class="tech-badge">CSS3</span>
@@ -307,8 +366,11 @@
     </div>
 
     <div class="text-center mt-4" data-aos="fade-up">
+      <a href="https://github.com/krishnagutta" target="_blank" rel="noopener noreferrer" class="btn projects-more-btn mr-2">
+        <i class="fab fa-github mr-2"></i>github.com/krishnagutta
+      </a>
       <a href="https://github.com/gkchaitanya1503" target="_blank" rel="noopener noreferrer" class="btn projects-more-btn">
-        <i class="fab fa-github mr-2"></i>See all on GitHub
+        <i class="fab fa-github mr-2"></i>github.com/gkchaitanya1503
       </a>
     </div>
   </div>
@@ -978,7 +1040,8 @@
       <div class="col-md-4 text-center mb-3 mb-md-0">
         <div class="footer-social">
           <a href="https://www.linkedin.com/in/krishna-gutta/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
-          <a href="https://github.com/gkchaitanya1503" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fab fa-github"></i></a>
+          <a href="https://github.com/krishnagutta" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fab fa-github"></i></a>
+          <a href="https://github.com/gkchaitanya1503" target="_blank" rel="noopener noreferrer" aria-label="GitHub 2"><i class="fab fa-github"></i></a>
           <a href="mailto:krishnac.gutta@gmail.com" aria-label="Email"><i class="fas fa-envelope"></i></a>
         </div>
       </div>
@@ -1373,7 +1436,7 @@
         } else if (match(low, ['mcp','model context','protocol','claude','anthropic','27 tool'])) {
           addBotMsg("Krishna pioneered <strong>AI-augmented HR infrastructure</strong>:<br>&#8226; Built a production <strong>Model Context Protocol (MCP) server</strong> exposing <strong>27 Workday HR tools</strong> to Claude AI — <a href='https://github.com/gkchaitanya1503/workday-oauth-poc' target='_blank'>view on GitHub</a><br>&#8226; Uses <strong>OAuth 2.0 PKCE</strong> and <strong>Okta SSO</strong> for secure authentication<br>&#8226; Enables employees to self-serve comp, PTO, org structure, and inbox approvals in plain English<br>&#8226; Also built a <strong>Jira-Workday automation</strong> using TypeScript MCP servers and Claude's API<br>&#8226; <strong>Workday Studio MCP</strong> — 19 tools for reading, writing, and validating Studio integrations (<a href='https://github.com/gkchaitanya1503/workday-studio-mcp' target='_blank'>GitHub</a>)");
         } else if (match(low, ['project','github','repo','open source','code'])) {
-          addBotMsg("Check out Krishna's featured projects:<br>&#8226; <strong>Workday MCP Server</strong> — 27 Workday tools for Claude AI (<a href='https://github.com/gkchaitanya1503/workday-oauth-poc' target='_blank'>GitHub</a>)<br>&#8226; <strong>Workday Studio MCP</strong> — 19 tools for Claude to read/write/validate Studio integrations (<a href='https://github.com/gkchaitanya1503/workday-studio-mcp' target='_blank'>GitHub</a>)<br>&#8226; <strong>Jira x Workday Automation</strong> — BOT commands routed to Claude + Workday<br>&#8226; <strong>This Portfolio</strong> (<a href='https://github.com/gkchaitanya1503/myportfolio' target='_blank'>GitHub</a>)<br><br>All repos at <a href='https://github.com/gkchaitanya1503' target='_blank'>github.com/gkchaitanya1503</a>");
+          addBotMsg("Check out Krishna's featured projects:<br>&#8226; <strong>Workday MCP Server</strong> — 27 Workday tools for Claude AI (<a href='https://github.com/gkchaitanya1503/workday-oauth-poc' target='_blank'>GitHub</a>)<br>&#8226; <strong>Workday Studio MCP</strong> — 19 tools for Claude to read/write/validate Studio integrations (<a href='https://github.com/gkchaitanya1503/workday-studio-mcp' target='_blank'>GitHub</a>)<br>&#8226; <strong>Workday Community MCP</strong> — Search docs, release notes &amp; KB from Claude (<a href='https://github.com/krishnagutta/workday-community-mcp' target='_blank'>GitHub</a>)<br>&#8226; <strong>Integration Monitor</strong> — AI-powered monitoring agent with Slack digests (<a href='https://github.com/krishnagutta/integration-monitor' target='_blank'>GitHub</a>)<br><br>Repos at <a href='https://github.com/krishnagutta' target='_blank'>github.com/krishnagutta</a> &amp; <a href='https://github.com/gkchaitanya1503' target='_blank'>github.com/gkchaitanya1503</a>");
         } else if (match(low, ['workato','automation','agentic','ai '])) {
           addBotMsg("Krishna is at the forefront of <strong>AI + HR automation</strong>:<br>&#8226; Built a production <strong>MCP server</strong> connecting Claude AI to Workday at Lyft<br>&#8226; <strong>Workato Agentic AI Basics</strong> certification (Dec 2025)<br>&#8226; <strong>Workato Foundations Level 1</strong> certification (Dec 2025)<br>&#8226; Developed Jira-Workday automation using <strong>TypeScript MCP servers</strong> and <strong>Claude's API</strong>");
         } else if (match(low, ['follower','linkedin follow','network','connection'])) {


### PR DESCRIPTION
## Summary
- Add **Workday Community MCP** project card — MCP server for Workday Community/Resource Center search via Coveo API (krishnagutta/workday-community-mcp)
- Add **Integration Monitor Agent** project card — AI-powered Jira monitoring with Claude classification + Slack digests (krishnagutta/integration-monitor)
- Link both GitHub profiles (`krishnagutta` + `gkchaitanya1503`) in footer, structured data, and project section
- Update chatbot with all public repos and both profile links
- Featured Projects now shows 6 cards in 3x2 grid

https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q)_