### PR TITLE
Add DevCon 2026 Hackathon 1st Place + title update + resume rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,6 @@
             </div>
             <div class="col-lg-5 mt-3 mt-lg-0">
               <img src="Images/devcon-1st-place.jpg" alt="Krishna Gutta — 1st Place, Workday DevCon 2026 Hackathon" class="project-image" loading="lazy">
-              <img src="Images/career-insights-coach-architecture.png" alt="Career Insights Coach Architecture" class="project-image mt-2" loading="lazy">
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add Workday DevCon 2026 Hackathon 1st Place win across the entire site
- Gold trophy badge in hero, full-width Career Insights Coach project card, impact stat, thought leadership card, awards card
- Title updated to "Product Lead Systems Engineer" everywhere
- Resume filename space removed (Krishna_Gutta_Resume_2026.docx)
- Chatbot awards response updated
- Full dark mode support for all gold winner styles

https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q)_