### PR TITLE
Amplify DevCon 2026 win across hero, meta, timeline, and chatbot

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,14 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-    <title>Krishna Gutta — AI-Augmented Workday Engineer &amp; MCP Pioneer</title>
-    <meta name="description" content="Krishna Gutta — 11+ years transforming enterprise HR through Workday integrations, AI-augmented infrastructure, and Model Context Protocol (MCP) servers at Lyft, Gilead, USAA, and more.">
+    <title>Krishna Gutta — 1st Place DevCon 2026 | AI-Augmented Workday Engineer</title>
+    <meta name="description" content="Krishna Gutta — 1st Place Workday DevCon 2026 Hackathon. 11+ years transforming enterprise HR through AI agents, MCP servers, and Workday integrations at Lyft, Gilead, USAA, and more.">
     <meta name="keywords" content="Workday Integration Engineer, MCP, Model Context Protocol, Claude AI, HCM, Payroll, PRISM, Extend, Studio, Krishna Gutta, AI HR">
 
     <!-- Open Graph / Social Sharing -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="Krishna Gutta — AI-Augmented Workday Engineer">
-    <meta property="og:description" content="11+ years transforming enterprise HR through AI-augmented Workday infrastructure, MCP servers, and scalable integrations at Lyft, Gilead, USAA, and more.">
+    <meta property="og:description" content="1st Place — Workday DevCon 2026 Hackathon. 11+ years building AI agents, MCP servers, and Workday integrations at Lyft, Gilead, USAA, and more.">
     <meta property="og:image" content="https://gkchaitanya1503.github.io/myportfolio/Images/Krishna_Gutta.jpg">
     <meta property="og:url" content="https://gkchaitanya1503.github.io/myportfolio/">
     <meta name="twitter:card" content="summary_large_image">
@@ -145,14 +145,7 @@
           <span class="typed-cursor">|</span>
         </div>
         <p class="hero-location"><i class="fas fa-map-marker-alt"></i> Boulder, CO</p>
-        <p class="hero-text">11+ years transforming enterprise HR ecosystems through Workday — now pioneering AI-augmented HR infrastructure with a production MCP server exposing 27 Workday tools to Claude AI.</p>
-        <a href="#projects" class="hero-build-badge">
-          <span class="hero-build-pulse"></span>
-          <i class="fas fa-rocket mr-2"></i>
-          <span class="hero-build-label">Latest build:</span>
-          <span class="hero-build-name">Workday MCP Server</span>
-          <i class="fas fa-arrow-right ml-2"></i>
-        </a>
+        <p class="hero-text">11+ years transforming enterprise HR ecosystems through Workday — from hackathon-winning AI agents to production MCP servers exposing 27 Workday tools to Claude AI.</p>
         <div class="hero-cta">
           <a href="#projects" class="btn hero-btn-primary">
             <i class="fas fa-code mr-2"></i>View Projects
@@ -724,6 +717,7 @@
           <span class="timeline-role">Product Lead Systems Engineer</span>
           <span class="timeline-date"><i class="far fa-calendar-alt mr-1"></i>Jan 2020 &ndash; Present &bull; Remote &mdash; Boulder, CO</span>
           <div class="timeline-achievements">
+            <div class="achievement"><i class="fas fa-trophy"></i> 1st Place — Workday DevCon 2026 Hackathon (Career Insights Coach)</div>
             <div class="achievement"><i class="fas fa-robot"></i> Pioneered production MCP server exposing 27 Workday tools to Claude AI</div>
             <div class="achievement"><i class="fas fa-star"></i> Led Mexico Dayforce payroll migration across US, Canada &amp; Mexico</div>
             <div class="achievement"><i class="fas fa-star"></i> Drove Free Now M&amp;A integration for ~900 employees across 10 EU countries</div>
@@ -1215,7 +1209,7 @@
   });
 
   // ==================== TYPING ANIMATION ====================
-  var phrases = ['AI-augmented HR infrastructure.','Workday MCP servers for Claude AI.','Workday integrations at scale.','PRISM analytics dashboards.','enterprise payroll systems.','custom Extend applications.'];
+  var phrases = ['hackathon-winning AI agents.','Workday MCP servers for Claude AI.','AI-augmented HR infrastructure.','Workday integrations at scale.','PRISM analytics dashboards.','custom Extend applications.'];
   var pi = 0, ci = 0, del = false, typedEl = document.getElementById('typed-text');
   (function typeLoop() {
     var cur = phrases[pi];
@@ -1488,6 +1482,8 @@
           addBotMsg("<strong>Certifications:</strong><br>&#8226; <strong>Workday Advanced Studio Pro</strong> — 97% score! (2019)<br>&#8226; <strong>Workday Pro Studio</strong> (2020)<br>&#8226; <strong>PRISM Analytics</strong> (2020)<br>&#8226; <strong>Workday Extend</strong> (Multiple)<br>&#8226; <strong>Workato Agentic AI Basics</strong> (2025)<br>&#8226; <strong>Workato Foundations Level 1</strong> (2025)<br><br>6+ industry-recognized credentials.");
         } else if (match(low, ['article','publish','write','blog','thought','alexa','voice'])) {
           addBotMsg("Krishna has published <strong>LinkedIn Pulse articles</strong> on:<br>&#8226; <strong>Workday Integration Best Practices</strong> — building scalable Studio integrations<br>&#8226; <strong>Connecting Alexa to Workday</strong> — voice AI meets enterprise HR<br><br>He shares insights with his <strong>8,000+ LinkedIn followers</strong>.");
+        } else if (match(low, ['devcon','hackathon','career insights','career coach'])) {
+          addBotMsg("<strong>1st Place — Workday DevCon 2026 Hackathon</strong> (Resorts World, Las Vegas)<br><br>Krishna's team built <strong>Career Insights Coach</strong> — an AI agent that coaches employees through career growth using live talent data. Built in <strong>24 hours</strong> across ~10 Workday technologies: Developer Agent, Extend, A2UI, Data Cloud, Orchestrate, ASOR, Prism, Workday Everywhere, and Claude.<br><br><strong>Team:</strong> Krishna Gutta, Austin Niehaus, Andrew Cesario, Bala Veeramachaneni<br><strong>1,500+</strong> in-person developers, <strong>~8,000</strong> online. Featured by official Workday LinkedIn pages.");
         } else if (match(low, ['award','best student','honor','achievement','recognition'])) {
           addBotMsg("<strong>Awards:</strong><br>&#8226; <strong>1st Place — Workday DevCon 2026 Hackathon</strong> (Resorts World, Las Vegas) — built 'Career Insights Coach' across ~10 Workday technologies in 24 hours. 1,500+ developers.<br>&#8226; <strong>Best Student Award</strong> — KL University (2007)<br>&#8226; <strong>Workday Advanced Studio Pro</strong> — scored <strong>97%</strong> (top percentile)");
         } else if (match(low, ['volunteer','community','workshop','vr1'])) {


### PR DESCRIPTION
## Summary
- Typed animation leads with "hackathon-winning AI agents."
- Hero text mentions hackathon win, redundant "Latest build" badge removed
- Page title + meta + OG descriptions lead with "1st Place DevCon 2026"
- Lyft timeline: hackathon win as top achievement
- Chatbot: dedicated devcon/hackathon/career-insights keyword trigger with full response

https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFhyhV1qxBwLvfh5DAVC3Q)_